### PR TITLE
Updates DB to include deviceId in SignatureNotice Table. 

### DIFF
--- a/ElectionAPI/Controllers/SignatureController.cs
+++ b/ElectionAPI/Controllers/SignatureController.cs
@@ -70,9 +70,11 @@ namespace ElectionAPI.Controllers
                 UOW.BeginTransaction();
                 Signature signature = this.GetSignatureFromBlockChain(electionChain);
                 // now check to make sure the nonce matches the expected nonce
-                int expectedNonce = await this.signatureRepository.GetExpectedNonce(UOW, signature.BallotId);
+                (int expectedNonce, string deviceId) = await this.signatureRepository.GetExpectedNonce(UOW, signature.BallotId);
 
-                if (signature == null || expectedNonce != electionChain.GetLatestBlock().Nonce)
+                // make sure the nonce and device id are correct
+                if (signature == null || expectedNonce != electionChain.GetLatestBlock().Nonce ||
+                    signature.DeviceId != deviceId)
                     return null;
 
                 Signature existingSignature = await this.GetByBallotId(signature.BallotId);

--- a/ElectionAPI/Repository/SignatureRepository.cs
+++ b/ElectionAPI/Repository/SignatureRepository.cs
@@ -19,7 +19,7 @@ namespace ElectionAPI.Repository
         Task<Signature> GetByBallotId(IUnitOfWork uow, Guid id);
         Task<Signature> UpdateBallotVotes(IUnitOfWork uow, Signature previousSignature, Signature signature);
         Task<SignatureNotice> NotifyPendingSubmittal(IDbConnection context, SignatureNotice notice);
-        Task<int> GetExpectedNonce(IUnitOfWork uow, Guid ballotId);
+        Task<(int, string)> GetExpectedNonce(IUnitOfWork uow, Guid ballotId);
     }
 
     public class SignatureRepository : BaseRepository, ISignatureRepository
@@ -92,9 +92,9 @@ namespace ElectionAPI.Repository
             return result;
         }
 
-        public async Task<int> GetExpectedNonce(IUnitOfWork uow, Guid ballotId)
+        public async Task<(int,string)> GetExpectedNonce(IUnitOfWork uow, Guid ballotId)
         {
-            int result = 0;
+            (int,string) result = (0, null);
             try
             {
                 result = await this.signatureService.GetExpectedNonce(uow, ballotId);

--- a/ElectionModels/SignatureNotice.cs
+++ b/ElectionModels/SignatureNotice.cs
@@ -7,6 +7,6 @@ namespace ElectionModels
         public Guid Id { get; set; }
         public Guid BallotId { get; set; }
         public int Nonce { get; set; }
-        
+        public string DeviceId { get; set; }
     }
 }

--- a/OneVote/OneVote/Services/DataService.cs
+++ b/OneVote/OneVote/Services/DataService.cs
@@ -218,12 +218,13 @@ namespace OneVote.Services
             return null;
         }
 
-        public static async Task<SignatureNotice> NotifyPendingSubmittal(int nonce, Guid ballotId)
+        public static async Task<SignatureNotice> NotifyPendingSubmittal(int nonce, Guid ballotId, string deviceId)
         {
             SignatureNotice notice = new SignatureNotice()
             {
                 BallotId = ballotId,
-                Nonce = nonce
+                Nonce = nonce,
+                DeviceId = deviceId
             };
             try
             {

--- a/OneVote/OneVote/ViewModels/ItemsViewModel.cs
+++ b/OneVote/OneVote/ViewModels/ItemsViewModel.cs
@@ -327,7 +327,7 @@ namespace OneVote.ViewModels
 
             BlockChain electionChain = await this.ConvertToBlockChain(sig);
             int nonce = electionChain.GetLatestBlock().Nonce;
-            var ans = await DataService.NotifyPendingSubmittal(nonce, model.BallotId);
+            var ans = await DataService.NotifyPendingSubmittal(nonce, model.BallotId, Models.Utils.GetId());
             if (ans.Id != Guid.Empty)
             {
                 Signature result = await DataService.PutSignature(electionChain);

--- a/PostgresDB/CreateDBAndTables.sql
+++ b/PostgresDB/CreateDBAndTables.sql
@@ -124,6 +124,7 @@ CREATE TABLE public.SignatureNotice
     Id uuid NOT NULL,
     Nonce integer NOT NULL,
     BallotId uuid NOT NULL,
+    DeviceId text,
     CreateDate timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
 )
 TABLESPACE pg_default;

--- a/PostgresDB/StoredProcedures2.sql
+++ b/PostgresDB/StoredProcedures2.sql
@@ -53,13 +53,13 @@ END;
 $func$ Language plpgsql;
 
 
-CREATE OR REPLACE FUNCTION SignatureNotice_Insert(id uuid, ballotid uuid, nonce int)
+CREATE OR REPLACE FUNCTION SignatureNotice_Insert(id uuid, ballotid uuid, nonce int, deviceid text)
 RETURNS SETOF SignatureNotice AS $func$
 DECLARE
-	sql text = 'INSERT INTO SignatureNotice (id, BallotId, Nonce, CreateDate) VALUES 
-	($1, $2, $3, current_timestamp) RETURNING *';
+	sql text = 'INSERT INTO SignatureNotice (id, ballotid, nonce, deviceid, createdate) VALUES 
+	($1, $2, $3, $4, current_timestamp) RETURNING *';
 BEGIN	
-	RETURN QUERY EXECUTE sql USING id, ballotid, nonce;
+	RETURN QUERY EXECUTE sql USING id, ballotid, nonce, deviceid;
 END;
 $func$ Language plpgsql;
 
@@ -71,7 +71,6 @@ BEGIN
 	RETURN QUERY EXECUTE sql USING ballotid;
 END;
 $func$ Language plpgsql;
-
 
 CREATE OR REPLACE FUNCTION Vote_Insert(id uuid, electionid uuid, ballotid uuid, categoryid uuid,
 	categorytypeid int, selectionid uuid, votestatus int, approvaldate timestamp)


### PR DESCRIPTION
 Update API to expected DeviceId with notification of pending submittal and to verify that the deviceId is correct when the signature arrives.

This update was to include a deviceId with the notice of pending signature submittal so that attempts to directly inject signature records need to first register a deviceId.